### PR TITLE
Use Node v20 for GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 19
           registry-url: https://registry.npmjs.org/
       - run: yarn install
       - run: yarn build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
           registry-url: https://registry.npmjs.org/
       - run: yarn install
       - run: yarn build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 19
           registry-url: https://registry.npmjs.org/
       - run: yarn install
       - run: yarn build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
           registry-url: https://registry.npmjs.org/
       - run: yarn install
       - run: yarn build


### PR DESCRIPTION
Changes Node version in GitHub actions to v20. Current version has the symlink issue we have seen other places.