### PR TITLE
Use container element ref in place of id

### DIFF
--- a/dev/serve.vue
+++ b/dev/serve.vue
@@ -46,7 +46,6 @@ export default {
   </select>
   <SeatsioSeatingChart
         v-if="selectedComponent === 'seatingChart'"
-        id="myChart"
         workspaceKey="publicDemoKey"
         event="smallTheatreEvent"
         region="eu"
@@ -67,7 +66,6 @@ export default {
     <SeatsioDesigner
       v-if="selectedComponent === 'chartDesigner'"
       region="eu"
-      id="myChartDesigner"
       workspaceKey="publicDemoKey"
       mode="readOnly"
       :language="language"
@@ -83,7 +81,6 @@ export default {
     <SeatsioEventManager
         v-if="selectedComponent === 'eventManager'"
         region="eu"
-        id="myEventManager"
         mode="manageCategories"
         :language="language"
         :chartJsUrl="chartJsUrl"

--- a/dev/serve.vue
+++ b/dev/serve.vue
@@ -40,28 +40,29 @@ export default {
 </script>
 
 <template>
-  <ComponentSelector @selectChartType="component => selectedComponent = component" />
-  <select v-model="language">
-    <option v-for="option in languages" :value="option">{{option}}</option>
-  </select>
-  <SeatsioSeatingChart
-        v-if="selectedComponent === 'seatingChart'"
-        workspaceKey="publicDemoKey"
-        event="smallTheatreEvent"
-        region="eu"
-        :language="language"
-        :chartJsUrl="chartJsUrl"
-        :messages="messages"
-        :objectColor="objectColor"
-        :tooltipInfo="tooltipInfo"
-        :priceFormatter="priceFormatter"
-        @renderStarted="onRenderStarted"
-        @objectClicked="onObjectClicked"
-        :pricing="[
-          { category: 1, price: 30 },
-          { category: 2, price: 40 },
-          { category: 3, price: 50 }
-        ]"
+  <div style="height: 100vh">
+    <ComponentSelector @selectChartType="component => selectedComponent = component" />
+    <select v-model="language">
+      <option v-for="option in languages" :value="option">{{option}}</option>
+    </select>
+    <SeatsioSeatingChart
+      v-if="selectedComponent === 'seatingChart'"
+      workspaceKey="publicDemoKey"
+      event="smallTheatreEvent"
+      region="eu"
+      :language="language"
+      :chartJsUrl="chartJsUrl"
+      :messages="messages"
+      :objectColor="objectColor"
+      :tooltipInfo="tooltipInfo"
+      :priceFormatter="priceFormatter"
+      @renderStarted="onRenderStarted"
+      @objectClicked="onObjectClicked"
+      :pricing="[
+        { category: 1, price: 30 },
+        { category: 2, price: 40 },
+        { category: 3, price: 50 }
+      ]"
     />
     <SeatsioDesigner
       v-if="selectedComponent === 'chartDesigner'"
@@ -91,10 +92,5 @@ export default {
         event="smallTheatreEvent"
         secretKey="demoKey"
     />
+  </div>
 </template>
-
-<style scoped>
-#myChart, #myChartDesigner, #myChartManager, #myEventManager {
-  height: 100vh
-}
-</style>

--- a/src/lib-components/seatsioDesigner.vue
+++ b/src/lib-components/seatsioDesigner.vue
@@ -14,7 +14,3 @@ export default defineComponent<SeatsioChartDesignerProps>({
   }
 })
 </script>
-
-<template>
-  <div :id="id"></div>
-</template>

--- a/src/lib-components/seatsioEmbeddable.vue
+++ b/src/lib-components/seatsioEmbeddable.vue
@@ -87,12 +87,5 @@
 </script>
 
 <template>
-  <div ref="container" class="chart-container"></div>
+  <div ref="container" style="width: 100%; height: 100%;"></div>
 </template>
-
-<style>
-.chart-container {
-  height: 100%;
-  width: 100%;
-}
-</style>

--- a/src/lib-components/seatsioEmbeddable.vue
+++ b/src/lib-components/seatsioEmbeddable.vue
@@ -22,10 +22,9 @@
         }
 
         const seatsio = await this.getSeatsio()
-
         const config = {
-          divId: this.$props.id,
-          ...this.propsAndAttrs()
+          ...this.propsAndAttrs(),
+          container: this.$refs.container
         }
         // @ts-ignore
         this.chart = this.createChart(seatsio, config).render()
@@ -86,3 +85,7 @@
     }
   })
 </script>
+
+<template>
+  <div ref="container"></div>
+</template>

--- a/src/lib-components/seatsioEmbeddable.vue
+++ b/src/lib-components/seatsioEmbeddable.vue
@@ -87,5 +87,12 @@
 </script>
 
 <template>
-  <div ref="container"></div>
+  <div ref="container" class="chart-container"></div>
 </template>
+
+<style>
+.chart-container {
+  height: 100%;
+  width: 100%;
+}
+</style>

--- a/src/lib-components/seatsioEventManager.vue
+++ b/src/lib-components/seatsioEventManager.vue
@@ -18,7 +18,3 @@ export default defineComponent<SeatsioEventManagerProps>({
     }
 })
 </script>
-
-<template>
-  <div :id="id"></div>
-</template>

--- a/src/lib-components/seatsioSeatingChart.vue
+++ b/src/lib-components/seatsioSeatingChart.vue
@@ -15,7 +15,3 @@ export default defineComponent<SeatsioSeatingChartProps>({
   }
 })
 </script>
-
-<template>
-  <div :id="id"></div>
-</template>


### PR DESCRIPTION
This PR changes the container element from having an `id` attribute to using an element ref. The configuration is now passed the container in place of `divId`.